### PR TITLE
Update paths for autounattended files for gui and core

### DIFF
--- a/win2019-core.json
+++ b/win2019-core.json
@@ -55,7 +55,7 @@
             "winrm_use_ssl": true,
             "winrm_insecure": true,
             "winrm_timeout": "4h",
-            "floppy_files": ["scripts/bios/autounattend.xml"],
+            "floppy_files": ["scripts/bios/core/autounattend.xml"],
             "shutdown_command": "shutdown /s /t 5 /f /d p:4:1 /c \"Packer Shutdown\"",
             "shutdown_timeout": "30m",
             "vboxmanage": [

--- a/win2019-gui.json
+++ b/win2019-gui.json
@@ -55,7 +55,7 @@
             "winrm_use_ssl": true,
             "winrm_insecure": true,
             "winrm_timeout": "4h",
-            "floppy_files": ["scripts/bios/autounattend.xml"],
+            "floppy_files": ["scripts/bios/gui/autounattend.xml"],
             "shutdown_command": "shutdown /s /t 5 /f /d p:4:1 /c \"Packer Shutdown\"",
             "shutdown_timeout": "30m",
             "vboxmanage": [


### PR DESCRIPTION
Thanks for adding Windows 2019 support to Packer! 

I had to update the paths to find the autounattended.xml files. 
